### PR TITLE
Add snapshot functionality

### DIFF
--- a/.changeset/hip-points-grin.md
+++ b/.changeset/hip-points-grin.md
@@ -1,0 +1,5 @@
+---
+"@wpmedia/ads-changeset-action": patch
+---
+
+Add ability to publish snapshot packages if project has changesets

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@changesets/action",
+  "name": "@wpmedia/ads-changeset-action",
   "version": "1.2.2",
   "main": "dist/index.js",
   "license": "MIT",


### PR DESCRIPTION
Adds logic in the `hasChangesets` branch to run an arbitrary command provided by the action under the `snapshot` key.

This will ensure that the `publishedPackages` output is populated if any publish action has taken place.